### PR TITLE
	modified:   README

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ SYNOPSIS
 
             my $ud = WebService::UrbanDictionary->new;
 
-            my $results = request('perl'); 
+            my $results = $ud->request('perl'); 
 
             for my $each (@{ $results->definitions }) {
                     printf "Definition: %s\n(by %s)\n\n", $each->definition, $each->author;

--- a/README.mkdn
+++ b/README.mkdn
@@ -12,7 +12,7 @@ version 2.014
 
         my $ud = WebService::UrbanDictionary->new;
 
-        my $results = request('perl'); 
+        my $results = $ud->request('perl'); 
 
         for my $each (@{ $results->definitions }) {
                 printf "Definition: %s\n(by %s)\n\n", $each->definition, $each->author;

--- a/README.pod
+++ b/README.pod
@@ -14,7 +14,7 @@ version 2.014
 
 	my $ud = WebService::UrbanDictionary->new;
 
-	my $results = request('perl'); 
+	my $results = $ud->request('perl'); 
 
 	for my $each (@{ $results->definitions }) {
 		printf "Definition: %s\n(by %s)\n\n", $each->definition, $each->author;

--- a/lib/WebService/UrbanDictionary/Term.pm
+++ b/lib/WebService/UrbanDictionary/Term.pm
@@ -43,7 +43,7 @@ WebService::UrbanDictionary::Term - Object for holding definitions and other dat
 
 	my $ud = WebService::UrbanDictionary->new;
 
-	my $results = request('perl'); 
+	my $results = $ud->request('perl'); 
 
 	my $definition = $results->definition;
 

--- a/lib/WebService/UrbanDictionary/Term/Definition.pm
+++ b/lib/WebService/UrbanDictionary/Term/Definition.pm
@@ -24,7 +24,7 @@ WebService::UrbanDictionary::Term::Definition - Wrapper for retreiving data from
 
 	my $ud = WebService::UrbanDictionary->new;
 
-	my $results = request('perl'); 
+	my $results = $ud->request('perl'); 
 
 	for my $each (@{ $results->definitions }) {
 		printf "Definition: %s\n(by %s)\n\n", $each->definition, $each->author;


### PR DESCRIPTION
```
modified:   README.mkdn
modified:   README.pod
modified:   lib/WebService/UrbanDictionary/Term.pm
modified:   lib/WebService/UrbanDictionary/Term/Definition.pm
```

The synopsis was broken in that the line: `my $results = request('perl');` would fail with errors.

Changing the line to `my $results = $ud->request('perl');` makes the example work.

The synopsis for WebService::UrbanDictionary::Term and WebService::UrbanDictionary::Term::Definition should also be changed to reflect the same.

I think there could be more examples for this module and it's missing documentation for "definitions".
